### PR TITLE
Explicitly configure the repos for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,14 @@
 version: 2
+registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2
+  google:
+    type: maven-repository
+    url: https://dl.google.com/dl/android/maven2
+  gradle:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -14,3 +24,7 @@ updates:
       - "hfhbd"
     open-pull-requests-limit: 25
     rebase-strategy: "disabled"
+    registries:
+      - maven-central
+      - google
+      - gradle


### PR DESCRIPTION
It is unable to fetch the repos defined in settings.gradle.kts