### PR TITLE
Set GITHUB_SHA to correct value for PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
           distribution: 'adopt'
           java-version: 17
       - uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
           dependency-graph: generate-and-submit
           gradle-home-cache-cleanup: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,14 @@ jobs:
             ~/.konan
       - name: Build with Gradle
         run: ./gradlew build
+        env:
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Detekt
         run: ./gradlew detekt
         if: always()
+        env:
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v2
         if: always()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
 
     env:
       GRADLE_OPTS: -Dorg.gradle.caching=true
+      GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +24,6 @@ jobs:
           distribution: 'adopt'
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-        env:
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         with:
           dependency-graph: generate-and-submit
           gradle-home-cache-cleanup: true
@@ -35,14 +34,10 @@ jobs:
             ~/.konan
       - name: Build with Gradle
         run: ./gradlew build
-        env:
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Detekt
         run: ./gradlew detekt
         if: always()
-        env:
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Upload SARIF to Github using the upload-sarif action
         uses: github/codeql-action/upload-sarif@v2
         if: always()


### PR DESCRIPTION
In re your comment here: https://github.com/actions/dependency-review-action/issues/545#issuecomment-1712549842

This appears to be a bug in https://github.com/gradle/github-dependency-graph-gradle-plugin, which is used indirectly by this project to submit dependencies. I'll file an issue with them to get it fixed, but in the meantime I believe this PR will help.

---

Unfortunately, `github.sha` is not a good choice for the SHA to use when submitting a dependency snapshot for a PR. In the case of a PR, `github.sha` is (IIRC) a hypothetical merge commit, rather than the head SHA for the PR itself.

Since what we want is the PR's head SHA, we get that from `github.event.pull_request.head.sha` when that variable is available. 

See https://github.com/gradle/github-dependency-graph-gradle-plugin#required-environment-variables for configuration reference for the Gradle plugin that submits dependencies.