### PR TITLE
[iOS] Use optional binding

### DIFF
--- a/iosApp/Shared/AsyncStream.swift
+++ b/iosApp/Shared/AsyncStream.swift
@@ -23,11 +23,10 @@ struct FlowStream<T>: AsyncSequence {
         func next() async -> T? {
             return try! await withTaskCancellationHandler {
                 do {
-                    let next = try await iterator.next()
-                    if (next == nil) {
-                        return Optional.none
+                    if let next = try await iterator.next() {
+                        return next as? T
                     } else {
-                        return Optional.some(next as! T)
+                        return nil
                     }
                 } catch let error as NSError {
                     let kotlinException = error.kotlinException


### PR DESCRIPTION
Use [Optional Binding](https://developer.apple.com/documentation/swift/optional#Optional-Binding) and return `nil` - common abbreviation for `Optional.none`.