### PR TITLE
[iOS] Use synthesized init for ViewModels

### DIFF
--- a/iosApp/Shared/ContentView.swift
+++ b/iosApp/Shared/ContentView.swift
@@ -43,10 +43,6 @@ struct ContentView: View {
 }
 
 struct Login: View {
-    init(viewModel: @autoclosure @escaping () -> LoginViewModel) {
-        self._viewModel = StateObject(wrappedValue: viewModel())
-    }
-
     @StateObject var viewModel: LoginViewModel
 
     @State private var error: Failure? = nil
@@ -78,10 +74,6 @@ struct Login: View {
 }
 
 struct Register: View {
-    init(viewModel: @autoclosure @escaping () -> RegisterViewModel) {
-        self._viewModel = StateObject(wrappedValue: viewModel())
-    }
-    
     @StateObject var viewModel: RegisterViewModel
 
     @State private var disableRegister = true

--- a/iosApp/Shared/Todos.swift
+++ b/iosApp/Shared/Todos.swift
@@ -9,10 +9,6 @@ import SwiftUI
 import clients
 
 struct Todos: View {
-    init(viewModel: @autoclosure @escaping () -> TodoViewModel) {
-        self._viewModel = StateObject(wrappedValue: viewModel())
-    }
-
     @StateObject var viewModel: TodoViewModel
 
     @State private var todos = [Todo]()
@@ -35,10 +31,8 @@ struct Todos_Previews: PreviewProvider {
         Todos(viewModel: TodoViewModel.init(repo: TestRepo()))
     }
 
-    class TestRepo: TodoRepository {
-        init() {
-
-        }
+    private final class TestRepo: TodoRepository {
+        init() {}
 
         func create(title: String, until: Instant?) async throws { }
 
@@ -49,9 +43,7 @@ struct Todos_Previews: PreviewProvider {
         func sync() async throws { }
 
         var todos: Flow {
-            get {
-                BuildersKt.emptyFlow()
-            }
+            BuildersKt.emptyFlow()
         }
     }
 }


### PR DESCRIPTION
We can use synthesized init for `struct`-s and get rid of the manual init of view models.